### PR TITLE
Remove machine-specific hardcoded paths

### DIFF
--- a/MusicDownloader.spec
+++ b/MusicDownloader.spec
@@ -1,13 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 """PyInstaller spec for Music Downloader macOS .app bundle."""
 
+import os
+import shutil
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-# ── Explicitly collect Qt6 plugins from the arm64 miniforge environment ───────
-# Pin directly to the miniforge PyQt6 plugins — clean arm64, no Qt5 present.
-# NOTE: This path is machine-specific. If rebuilding on a different machine,
-# update this to match your local PyQt6 installation path.
-_QT6_PLUGINS = "/Users/moseskaplan/miniforge-arm64/lib/python3.13/site-packages/PyQt6/Qt6/plugins"
+# ── Dynamically locate Qt6 plugins from the active Python environment ─────────
+import PyQt6
+_QT6_PLUGINS = os.path.join(os.path.dirname(PyQt6.__file__), "Qt6", "plugins")
+
+# ── Dynamically locate ffmpeg ─────────────────────────────────────────────────
+_FFMPEG = shutil.which("ffmpeg")
+if not _FFMPEG:
+    raise FileNotFoundError("ffmpeg not found on PATH. Install it (e.g. brew install ffmpeg) before building.")
 
 pyqt6_datas = [
     # macOS window system plugin — required for any GUI to appear
@@ -45,7 +50,7 @@ a = Analysis(
     ["mdownloader/__main__.py"],        # entry point
     pathex=["."],                       # project root on sys.path
     binaries=[
-        ("/usr/local/bin/ffmpeg", "."), # bundle ffmpeg at _MEIPASS root
+        (_FFMPEG, "."),                 # bundle ffmpeg at _MEIPASS root
     ],
     datas=pyqt6_datas,
     hiddenimports=hidden,

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ music-downloader/
 ## Running tests
 
 ```bash
+# Install runtime and development (test) dependencies
+pip install -r requirements.txt -r requirements-dev.txt
+
+# Run the test suite
 python3 -m pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Requires **ffmpeg** and **PyInstaller** installed on the build machine. The spec
 ```bash
 cd music-downloader
 brew install ffmpeg
+python3 -m pip install -r requirements.txt
 python3 -m pip install pyinstaller
 python3 -m PyInstaller MusicDownloader.spec
 ```

--- a/README.md
+++ b/README.md
@@ -36,13 +36,8 @@ Build the `.exe` yourself using the instructions in [`docs/build-windows.md`](do
 
 ### Requirements
 
-- **miniforge arm64 Python** at `~/miniforge-arm64` (native Apple Silicon)
+- **Python 3.11+**
 - **ffmpeg** — required by yt-dlp for MP3 conversion when running from source
-
-Install miniforge:
-```bash
-brew install miniforge
-```
 
 Install ffmpeg:
 ```bash
@@ -61,13 +56,13 @@ cd music-downloader
 **2. Install Python dependencies**
 
 ```bash
-~/miniforge-arm64/bin/pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 **3. Launch**
 
 ```bash
-~/miniforge-arm64/bin/python3 -m mdownloader
+python3 -m mdownloader
 ```
 
 ---
@@ -76,22 +71,23 @@ cd music-downloader
 
 ### macOS (.app)
 
+Requires **ffmpeg** and **PyInstaller** installed on the build machine. The spec file auto-detects both `ffmpeg` and the PyQt6 plugins path at build time.
+
 ```bash
 cd music-downloader
-~/miniforge-arm64/bin/pip install pyinstaller
-~/miniforge-arm64/bin/pyinstaller MusicDownloader.spec
+brew install ffmpeg
+python3 -m pip install pyinstaller
+python3 -m PyInstaller MusicDownloader.spec
 ```
 
 Output: `dist/Music Downloader.app`
-
-> **Note:** `MusicDownloader.spec` hardcodes the miniforge path at `~/miniforge-arm64`. If rebuilding on a different machine, update the `_QT6_PLUGINS` path in the spec to match your local PyQt6 installation.
 
 ### Windows (.exe)
 
 See [`docs/build-windows.md`](docs/build-windows.md) for full step-by-step instructions.
 
 ```
-pyinstaller MusicDownloader-Windows.spec
+python -m PyInstaller MusicDownloader-Windows.spec
 ```
 
 Output: `dist\MusicDownloader\MusicDownloader.exe`
@@ -186,7 +182,7 @@ music-downloader/
 ## Running tests
 
 ```bash
-~/miniforge-arm64/bin/python3 -m pytest
+python3 -m pytest
 ```
 
 ---

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -46,8 +46,8 @@ cd music-downloader
 ### 4. Install Python dependencies
 
 ```
-pip install -r requirements.txt
-pip install pyinstaller
+python -m pip install -r requirements.txt
+python -m pip install pyinstaller
 ```
 
 ---
@@ -72,7 +72,7 @@ C:\ffmpeg\bin\ffmpeg.exe -version
 From the `music-downloader` folder, run:
 
 ```
-pyinstaller MusicDownloader-Windows.spec
+python -m PyInstaller MusicDownloader-Windows.spec
 ```
 
 This will take a few minutes. When it finishes you'll see:


### PR DESCRIPTION
This PR addresses two issues:
- The macOS build config MusicDownloader.spec and docs hardcoded paths specific to the original developer's machine. This meant the build would fail on any other machine without manually editing paths first. 

- The README also listed miniforge as a prerequisite, which didn't actually appear to be required by the project

Proposed changes:

- Replaced miniforge prerequisite with generic Python 3.11+

- Changed all ~/miniforge-arm64/bin/pip → python3 -m pip

- Changed all ~/miniforge-arm64/bin/python3 → python3

- Changed pyinstaller → python3 -m PyInstaller (avoids PATH issues)

- Added note that the spec file auto-detects paths at build time

- Added ffmpeg as an explicit build prerequisite

- Removed outdated note about manually updating _QT6_PLUGINS path

In the build-windows.md section:

- Changed pip install → python -m pip install

- Changed pyinstaller → python -m PyInstaller

Intended Result
Any developer can now clone the repo and build on any Mac (or Windows machine) without editing any paths. The only prerequisites are Python, ffmpeg, and the pip dependencies whose paths are all auto-detected at build time.